### PR TITLE
Fix RoleAssignmentUpdateNotPermitted Error

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-# AVM core team owns key files
-.github/policies/ @Azure/avm-core-team-technical-terraform
 .github/CODEOWNERS @Azure/avm-core-team-technical-terraform

--- a/avm
+++ b/avm
@@ -1,12 +1,27 @@
 #!/usr/bin/env sh
 
+# Create a temporary copy of this script to avoid self-modification issues
+if [ -z "$AVM_FORKED" ]; then
+  # Create temporary directory and file
+    TEMP_DIR=$(mktemp -d)
+    TEMP_FILE="$TEMP_DIR/avm_$(date +%s)_$RANDOM"
+    # Copy the current script to the temporary file
+    cp "$0" "$TEMP_FILE"
+    chmod +x "$TEMP_FILE"
+
+    export AVM_FORKED=1
+    # Use exec to fork to a new process and not return to the script
+    exec "$TEMP_FILE" "$@"
+fi
+
 usage () {
   echo "Usage: avm <make target>"
 }
 
 CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-docker}
 
-if [ ! "$(command -v "$CONTAINER_RUNTIME")" ]; then
+
+if [ ! "$(command -v "$CONTAINER_RUNTIME")" ] && [ -z "$AVM_IN_CONTAINER" ]; then
     echo "Error: $CONTAINER_RUNTIME is not installed. Please install $CONTAINER_RUNTIME first."
     exit 1
 fi
@@ -20,6 +35,13 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
+# Set pull option based on AVM_NO_CONTAINER_PULL
+if [ -z "$AVM_NO_CONTAINER_PULL" ]; then
+  PULL_OPTION="--pull always"
+else
+  PULL_OPTION=""
+fi
+
 # Check if AZURE_CONFIG_DIR is set, if not, set it to ~/.azure
 if [ -z "$AZURE_CONFIG_DIR" ]; then
   AZURE_CONFIG_DIR="$HOME/.azure"
@@ -28,7 +50,7 @@ fi
 # Check if we are running in a container
 # If we are then just run make directly
 if [ -z "$AVM_IN_CONTAINER" ]; then
-  $CONTAINER_RUNTIME run --pull always --user "$(id -u):$(id -g)" --rm -v "$(pwd)":/src -w /src -v $AZURE_CONFIG_DIR:/azureconfig -e AZURE_CONFIG_DIR=/azureconfig -e GITHUB_TOKEN -e GITHUB_REPOSITORY -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e GITHUB_REPOSITORY_OWNER $AVM_IMAGE make "$1"
+  $CONTAINER_RUNTIME run $PULL_OPTION --user "$(id -u):$(id -g)" --rm -v "$(pwd)":/src -w /src -v $AZURE_CONFIG_DIR:/azureconfig -e AZURE_CONFIG_DIR=/azureconfig -e GITHUB_TOKEN -e GITHUB_REPOSITORY -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e GITHUB_REPOSITORY_OWNER $AVM_IMAGE make "$1"
 else
   make "$1"
 fi

--- a/avm.bat
+++ b/avm.bat
@@ -1,5 +1,27 @@
 @echo off
-SETLOCAL
+SETLOCAL EnableDelayedExpansion
+
+REM Check if this is the original script or a forked copy
+IF NOT DEFINED AVM_FORKED (
+    REM Create a temporary directory and file
+    SET TEMP_DIR="%TEMP%\avm_temp_%RANDOM%"
+    MKDIR !TEMP_DIR! 2>NUL
+    SET TEMP_FILE=!TEMP_DIR!\avm_%RANDOM%.bat
+
+    REM Copy the current script to the temporary file
+    COPY "avm.bat" !TEMP_FILE! >NUL
+
+    REM Execute the temporary file with AVM_FORKED=1 and all original arguments
+    SET AVM_FORKED=1
+    CALL !TEMP_FILE! %*
+    SET EXIT_CODE=%ERRORLEVEL%
+
+    REM Clean up
+    DEL /Q !TEMP_FILE! 2>NUL
+    RMDIR /Q !TEMP_DIR! 2>NUL
+
+    EXIT /B !EXIT_CODE!
+)
 
 REM Set CONTAINER_RUNTIME to its current value if it's already set, or docker if it's not
 IF DEFINED CONTAINER_RUNTIME (SET "CONTAINER_RUNTIME=%CONTAINER_RUNTIME%") ELSE (SET "CONTAINER_RUNTIME=docker")

--- a/examples/complete/terraform.tf
+++ b/examples/complete/terraform.tf
@@ -1,5 +1,6 @@
 terraform {
   required_version = "~> 1.9"
+
   required_providers {
     alz = {
       source  = "Azure/alz"

--- a/examples/custom-architecture-definition/terraform.tf
+++ b/examples/custom-architecture-definition/terraform.tf
@@ -1,5 +1,6 @@
 terraform {
   required_version = "~> 1.9"
+
   required_providers {
     alz = {
       source  = "Azure/alz"

--- a/examples/custom-policy-assignment/terraform.tf
+++ b/examples/custom-policy-assignment/terraform.tf
@@ -1,5 +1,6 @@
 terraform {
   required_version = "~> 1.9"
+
   required_providers {
     alz = {
       source  = "Azure/alz"

--- a/examples/default/terraform.tf
+++ b/examples/default/terraform.tf
@@ -1,5 +1,6 @@
 terraform {
   required_version = "~> 1.9"
+
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ module "user_assigned_managed_identity" {
 }
 
 resource "azapi_resource" "role_assignments" {
-  name      = uuidv5("oid", "${var.role_definition_id}-${var.user_assigned_managed_identity_name}")
+  name      = uuidv5("oid", "${var.role_definition_id}-${var.user_assigned_managed_identity_name}-${var.root_management_group_name}")
   parent_id = "/providers/Microsoft.Management/managementGroups/${var.root_management_group_name}"
   type      = "Microsoft.Authorization/roleAssignments@2022-04-01"
   body = {

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,6 @@
 terraform {
   required_version = "~> 1.9"
+
   required_providers {
     azapi = {
       source  = "azure/azapi"


### PR DESCRIPTION
## Description

Fixes #10 

Changed the role assignment name to include the root management group name to avoid the `RoleAssignmentUpdateNotPermitted` error. A possible secondary deployment to a different scope will now generate a different ID.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
