### PR TITLE
refactor: rename root_management_group_name to root_management_group_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Description: Azure region where the resource should be deployed.
 
 Type: `string`
 
-### <a name="input_root_management_group_name"></a> [root\_management\_group\_name](#input\_root\_management\_group\_name)
+### <a name="input_root_management_group_id"></a> [root\_management\_group\_id](#input\_root\_management\_group\_id)
 
-Description: The name (ID) of the management group.
+Description: The ID of the management group. Possible values are 'alz' or a custom management group ID.
 
 Type: `string`
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -21,7 +21,7 @@ provider "azurerm" {
 }
 
 locals {
-  root_management_group_name = "alz"
+  root_management_group_id = "alz"
 }
 
 module "amba_alz" {
@@ -32,7 +32,7 @@ module "amba_alz" {
   count = var.bring_your_own_user_assigned_managed_identity ? 0 : 1
 
   location                            = var.location
-  root_management_group_name          = local.root_management_group_name
+  root_management_group_id          = local.root_management_group_id
   resource_group_name                 = var.resource_group_name
   tags                                = var.tags
   user_assigned_managed_identity_name = var.user_assigned_managed_identity_name

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -14,7 +14,7 @@ provider "azurerm" {
 }
 
 locals {
-  root_management_group_name = "alz"
+  root_management_group_id = "alz"
 }
 
 module "amba_alz" {
@@ -25,7 +25,7 @@ module "amba_alz" {
   count = var.bring_your_own_user_assigned_managed_identity ? 0 : 1
 
   location                            = var.location
-  root_management_group_name          = local.root_management_group_name
+  root_management_group_id            = local.root_management_group_id
   resource_group_name                 = var.resource_group_name
   tags                                = var.tags
   user_assigned_managed_identity_name = var.user_assigned_managed_identity_name

--- a/examples/custom-architecture-definition/README.md
+++ b/examples/custom-architecture-definition/README.md
@@ -27,7 +27,7 @@ provider "azurerm" {
 }
 
 locals {
-  root_management_group_name = jsondecode(file("${path.root}/lib/custom.alz_architecture_definition.json")).management_groups[0].id
+  root_management_group_id = jsondecode(file("${path.root}/lib/custom.alz_architecture_definition.json")).management_groups[0].id
 }
 
 module "amba_alz" {
@@ -38,7 +38,7 @@ module "amba_alz" {
   count = var.bring_your_own_user_assigned_managed_identity ? 0 : 1
 
   location                            = var.location
-  root_management_group_name          = local.root_management_group_name
+  root_management_group_id          = local.root_management_group_id
   resource_group_name                 = var.resource_group_name
   tags                                = var.tags
   user_assigned_managed_identity_name = var.user_assigned_managed_identity_name
@@ -52,7 +52,7 @@ module "amba_policy" {
   location           = var.location
   parent_resource_id = data.azapi_client_config.current.tenant_id
   policy_assignments_to_modify = {
-    (local.root_management_group_name) = {
+    (local.root_management_group_id) = {
       policy_assignments = {
         Deploy-AMBA-Notification = {
           parameters = {

--- a/examples/custom-architecture-definition/main.tf
+++ b/examples/custom-architecture-definition/main.tf
@@ -20,7 +20,7 @@ provider "azurerm" {
 }
 
 locals {
-  root_management_group_name = jsondecode(file("${path.root}/lib/custom.alz_architecture_definition.json")).management_groups[0].id
+  root_management_group_id = jsondecode(file("${path.root}/lib/custom.alz_architecture_definition.json")).management_groups[0].id
 }
 
 module "amba_alz" {
@@ -31,7 +31,7 @@ module "amba_alz" {
   count = var.bring_your_own_user_assigned_managed_identity ? 0 : 1
 
   location                            = var.location
-  root_management_group_name          = local.root_management_group_name
+  root_management_group_id            = local.root_management_group_id
   resource_group_name                 = var.resource_group_name
   tags                                = var.tags
   user_assigned_managed_identity_name = var.user_assigned_managed_identity_name
@@ -45,7 +45,7 @@ module "amba_policy" {
   location           = var.location
   parent_resource_id = data.azapi_client_config.current.tenant_id
   policy_assignments_to_modify = {
-    (local.root_management_group_name) = {
+    (local.root_management_group_id) = {
       policy_assignments = {
         Deploy-AMBA-Notification = {
           parameters = {

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -18,7 +18,7 @@ module "amba_alz" {
   source = "../../"
 
   location                            = "swedencentral"
-  root_management_group_name          = "alz"
+  root_management_group_id          = "alz"
   resource_group_name                 = module.naming.resource_group.name_unique
   user_assigned_managed_identity_name = module.naming.user_assigned_identity.name_unique
 }

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -11,7 +11,7 @@ module "amba_alz" {
   source = "../../"
 
   location                            = "swedencentral"
-  root_management_group_name          = "alz"
+  root_management_group_id            = "alz"
   resource_group_name                 = module.naming.resource_group.name_unique
   user_assigned_managed_identity_name = module.naming.user_assigned_identity.name_unique
 }

--- a/main.tf
+++ b/main.tf
@@ -22,8 +22,8 @@ module "user_assigned_managed_identity" {
 }
 
 resource "azapi_resource" "role_assignments" {
-  name      = uuidv5("oid", "${var.role_definition_id}-${var.user_assigned_managed_identity_name}-${var.root_management_group_name}")
-  parent_id = "/providers/Microsoft.Management/managementGroups/${var.root_management_group_name}"
+  name      = uuidv5("oid", "${var.role_definition_id}-${var.user_assigned_managed_identity_name}-${var.root_management_group_id}")
+  parent_id = "/providers/Microsoft.Management/managementGroups/${var.root_management_group_id}"
   type      = "Microsoft.Authorization/roleAssignments@2022-04-01"
   body = {
     properties = {

--- a/variables.tf
+++ b/variables.tf
@@ -6,9 +6,9 @@ variable "location" {
   nullable    = false
 }
 
-variable "root_management_group_name" {
+variable "root_management_group_id" {
   type        = string
-  description = "The name (ID) of the management group."
+  description = "The ID of the management group. Possible values are 'alz' or a custom management group ID."
   nullable    = false
 }
 


### PR DESCRIPTION
This PR renames the variable _root_management_group_name_ to _root_management_group_id_ across the module for improved clarity and consistency.

### Motivation
The previous variable name root_management_group_name was misleading, as the value expected is actually the ID of the management group, not its display name. This change aligns the variable naming with its actual purpose and expected input value.

### Changes

- Renamed root_management_group_name to root_management_group_id in:
    - variables.tf
    - main.tf
    - All example configurations (examples)
    - Documentation (README.md)
    - Updated variable descriptions to reflect the new naming

### Type of Change
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  Refactor (non-breaking change that improves code quality/clarity)
- [ ]  New feature (non-breaking change which adds functionality)
- [x]  Breaking change (fix or feature that would cause existing functionality to not work as expected)

Breaking Change Notice
⚠️ This is a breaking change. Users upgrading to this version must update their Terraform configurations to use root_management_group_id instead of root_management_group_name.